### PR TITLE
fix: set LANG and LC_ALL for emailconverter command

### DIFF
--- a/lib/Service/ConversionService.php
+++ b/lib/Service/ConversionService.php
@@ -42,7 +42,12 @@ class ConversionService {
 			$resultPath
 		];
 
-		$process = proc_open($command, $descriptors, $pipes);
+		$env = [
+			'LANG=C.UTF-8',
+			'LC_ALL=C.UTF-8',
+		];
+
+		$process = proc_open($command, $descriptors, $pipes, null, $env);
 		if ($process === false) {
 			throw new ConversionException('Could not invoke emailconverter.jar');
 		}


### PR DESCRIPTION
Fix #29 
Fix #31 

Ensures UTF-8 compatibility when passing filenames to the external emailconverter command. Nextcloud filenames are UTF-8 encoded, so the process requires a UTF-8 locale setting to handle them correctly.